### PR TITLE
Remove multiline string

### DIFF
--- a/cmake/modules/Common.cmake
+++ b/cmake/modules/Common.cmake
@@ -84,10 +84,7 @@ macro(SSVCMake_setDefaultFlags)
 #{
 	message("SSVCMake: setting default flags")
 
-	set(SSVCMAKE_COMMON_FLAGS "-std=c++1y -pthread \
-		-Wall -Wextra -Wpedantic -Wundef -Wshadow -Wno-missing-field-initializers \
-		-Wpointer-arith -Wcast-align -Wwrite-strings -Wno-unreachable-code \
-		-Wnon-virtual-dtor -Woverloaded-virtual")
+	set(SSVCMAKE_COMMON_FLAGS "-std=c++1y -pthread -Wall -Wextra -Wpedantic -Wundef -Wshadow -Wno-missing-field-initializers -Wpointer-arith -Wcast-align -Wwrite-strings -Wno-unreachable-code -Wnon-virtual-dtor -Woverloaded-virtual")
 
 	if("${CMAKE_BUILD_TYPE}" STREQUAL "WIP")
 	#{


### PR DESCRIPTION
Using this module on Linux (cmake 2.8.12.2) I'm getting the error:

```
CMake Error at extlibs/SSVCMake/cmake/modules/Common.cmake:87 (set):
Syntax error in cmake code at
extlibs/SSVCMake/cmake/modules/Common.cmake:87
    when parsing string
    -std=c++1y -pthread \
        -Wall -Wextra -Wpedantic -Wundef -Wshadow -Wno-missing-field-initializers \
    -Wpointer-arith -Wcast-align -Wwrite-strings -Wno-unreachable-code \
    -Wnon-virtual-dtor -Woverloaded-virtual
  syntax error, unexpected cal_SYMBOL, expecting $end (99)
```

Caused by the multiline string. Removing the "\" fixed the problem.
