### PR TITLE
'c++1y' is deprecated

### DIFF
--- a/cmake/modules/Common.cmake
+++ b/cmake/modules/Common.cmake
@@ -84,7 +84,7 @@ macro(SSVCMake_setDefaultFlags)
 #{
     message("SSVCMake: setting default flags")
 
-    set(SSVCMAKE_COMMON_FLAGS "-std=c++1y -Wall -Wextra -Wpedantic -Wundef -Wshadow -Wno-missing-field-initializers -Wpointer-arith -Wcast-align -Wwrite-strings -Wno-unreachable-code -Wnon-virtual-dtor -Woverloaded-virtual")
+    set(SSVCMAKE_COMMON_FLAGS "-std=c++14 -Wall -Wextra -Wpedantic -Wundef -Wshadow -Wno-missing-field-initializers -Wpointer-arith -Wcast-align -Wwrite-strings -Wno-unreachable-code -Wnon-virtual-dtor -Woverloaded-virtual")
 
     if("${CMAKE_BUILD_TYPE}" STREQUAL "WIP")
     #{


### PR DESCRIPTION
According to the gcc docs: https://gcc.gnu.org/onlinedocs/gcc/C-Dialect-Options.html#index-std-112
